### PR TITLE
Go のバージョンを 1.17 -> 1.18 に変更 

### DIFF
--- a/roles/go/vars/main.yml
+++ b/roles/go/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 
-go_version: 1.17.7
+go_version: 1.18


### PR DESCRIPTION
Go v1.18 がリリースされたので vars/ 配下のバージョンを変更しています。

参考: https://go.dev/dl/